### PR TITLE
Use 'var' instead of 'let'.

### DIFF
--- a/moment-msdate.js
+++ b/moment-msdate.js
@@ -27,7 +27,7 @@
 	 * @returns moment
 	 */
 	moment.fromOADate = function (msDate, offsetToUtcInMinutes) {
-		let jO = new Date(((msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
+		var jO = new Date(((msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
 		const tz = isNaN(parseInt(offsetToUtcInMinutes, 10)) ? jO.getTimezoneOffset() : offsetToUtcInMinutes;
 		jO = new Date((((msDate - MS_DAY_OFFSET) + (tz / (60 * 24))) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
 		return moment(jO);


### PR DESCRIPTION
In this case they are equivalent, and this allows UglifyJS not to break
when parsing it.